### PR TITLE
SEO: add missing pages to sitemap; noindex legal pages

### DIFF
--- a/app/privacy-policy/layout.tsx
+++ b/app/privacy-policy/layout.tsx
@@ -4,6 +4,10 @@ import type { Metadata } from 'next'
 export const metadata: Metadata = {
   title: 'Privacy Policy | Blueprint Studio',
   description: 'Privacy Policy for Blueprint Studio',
+  // Legal boilerplate: keep it out of search results but let link equity flow.
+  robots: { index: false, follow: true },
+  // Override the root layout's canonical ('/') so this page doesn't point at the homepage.
+  alternates: { canonical: '/privacy-policy' },
   openGraph: {
     title: 'Privacy Policy | Blueprint Studio',
     description: 'Privacy Policy for Blueprint Studio',

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -19,8 +19,13 @@ export default function sitemap(): MetadataRoute.Sitemap {
 
   return [
     { url: `${base}/`,              lastModified: now, changeFrequency: 'weekly', priority: 1 },
+    // Service / offering pages
+    { url: `${base}/brand`,         lastModified: now, changeFrequency: 'weekly',  priority: 0.8 },
+    { url: `${base}/launch`,        lastModified: now, changeFrequency: 'weekly',  priority: 0.8 },
+    { url: `${base}/launch-videos`, lastModified: now, changeFrequency: 'monthly', priority: 0.7 },
+    // Case study
+    { url: `${base}/brands/jinba`,  lastModified: now, changeFrequency: 'monthly', priority: 0.6 },
     ...blogEntries,
-    { url: `${base}/terms`, lastModified: now, changeFrequency: 'yearly', priority: 0.2 },
-    { url: `${base}/privacy-policy`, lastModified: now, changeFrequency: 'yearly', priority: 0.2 },
+    // /terms and /privacy-policy are intentionally excluded — they're noindex (see their layout.tsx)
   ]
 }

--- a/app/terms/layout.tsx
+++ b/app/terms/layout.tsx
@@ -4,6 +4,10 @@ import type { Metadata } from 'next'
 export const metadata: Metadata = {
   title: 'Terms & Conditions | Blueprint Studio',
   description: 'Terms and Conditions for Blueprint Studio',
+  // Legal boilerplate: keep it out of search results but let link equity flow.
+  robots: { index: false, follow: true },
+  // Override the root layout's canonical ('/') so this page doesn't point at the homepage.
+  alternates: { canonical: '/terms' },
   openGraph: {
     title: 'Terms & Conditions | Blueprint Studio',
     description: 'Terms and Conditions for Blueprint Studio',


### PR DESCRIPTION
## What
Fixes the sitemap gap flagged during an SEO audit + a canonical bug on the legal pages.

### Sitemap (`app/sitemap.ts`)
Added four pages that had full canonical + OpenGraph metadata but were never in the sitemap (Google only discovered them via internal links):
- `/brand` — Brand Identity service page
- `/launch` — Full Launch Package
- `/launch-videos` — Launch Videos
- `/brands/jinba` — Jinba case study

Removed `/terms` and `/privacy-policy` (see below).

### Legal pages (`app/terms/layout.tsx`, `app/privacy-policy/layout.tsx`)
They exported no `robots`/`canonical`, so they inherited the root layout's `canonical: '/'` — effectively telling Google they were the homepage. Now:
- `robots: { index: false, follow: true }` — keep legal boilerplate out of search results, still pass link equity
- self-canonical (`/terms`, `/privacy-policy`)
- removed from the sitemap (a URL that's both sitemap-listed **and** noindex is a conflicting signal Search Console flags)

## Verified (local dev server)
- `sitemap.xml` lists the 4 new URLs; terms/privacy gone ✅
- `/terms` + `/privacy-policy` render `noindex, follow` + self-canonical ✅
- `/brand` regression check: still `index, follow` + canonical `/brand` ✅
- `tsc --noEmit` clean ✅

## Note
`noindex` drops the legal pages from Google on the next crawl (not instant) — expect them to fall out of results within a few weeks.

## Follow-up (separate PR)
JSON-LD for `/launch` + `/launch-videos`, and canonical/keywords/JSON-LD for `/brands/jinba`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)