### PR TITLE
SEO: structured data for /launch, /launch-videos, /brands/jinba

### DIFF
--- a/app/brands/jinba/page.tsx
+++ b/app/brands/jinba/page.tsx
@@ -14,6 +14,18 @@ import { ColorScalesSection } from "./ColorScalesSection";
 export const metadata: Metadata = {
   title: "Jinba — Brand Identity & Design System",
   description: "Brand identity, logo system, color palette, typography, and design system for Jinba — crafted by Blueprint Studio.",
+  keywords: [
+    "brand identity case study",
+    "design system",
+    "logo system",
+    "color palette",
+    "typography",
+    "brand guidelines",
+    "Jinba",
+  ],
+  alternates: {
+    canonical: "/brands/jinba",
+  },
   openGraph: {
     title: "Jinba — Brand Identity & Design System",
     description: "Brand identity, logo system, color palette, typography, and design system for Jinba — crafted by Blueprint Studio.",
@@ -120,9 +132,31 @@ function LinkedInDownloadRow() {
   );
 }
 
+// Page-specific structured data (the layout already provides WebSite +
+// Organization). Describes the Jinba brand-identity case study.
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@type": "CreativeWork",
+  name: "Jinba — Brand Identity & Design System",
+  description:
+    "Brand identity, logo system, color palette, typography, and design system for Jinba — crafted by Blueprint Studio.",
+  url: "https://blueprintstudio.ai/brands/jinba",
+  image: "https://blueprintstudio.ai/brands/jinba/og-image.png",
+  about: "Jinba",
+  creator: {
+    "@type": "Organization",
+    name: "Blueprint Studio",
+    url: "https://blueprintstudio.ai",
+  },
+};
+
 export default function JinbaPage() {
   return (
     <div className="min-h-screen bg-[#F5F5F5] max-w-[1800px] mx-auto lg:pl-[10rem]">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
       <BrandNav clientName="Jinba" logoSrc="/brands/jinba/dl/lockup-small-dark.png" />
       <BrandToC chapters={TOC_CHAPTERS} pdfHref="https://drive.google.com/file/d/1zZaz_NnLIcT-b2WeNSgJn1VO9Nry83dx/view?usp=sharing" />
 

--- a/app/launch-videos/page.tsx
+++ b/app/launch-videos/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import LaunchVideosComponent from "@/components/LaunchVideos/index";
 
 export const metadata: Metadata = {
   // Layout template appends " | Blueprint Studio" — keep this bare to avoid doubling.
@@ -45,4 +46,32 @@ export const metadata: Metadata = {
   },
 };
 
-export { default } from "@/components/LaunchVideos/index";
+// Page-specific structured data (the layout already provides WebSite +
+// Organization). Describes the Launch Videos production service.
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@type": "Service",
+  name: "Launch Videos",
+  serviceType: "Launch video production",
+  description:
+    "Get your launch video in 7 days. Studio quality, startup speed. You focus on shipping. We'll handle the video.",
+  url: "https://blueprintstudio.ai/launch-videos",
+  areaServed: "Worldwide",
+  provider: {
+    "@type": "Organization",
+    name: "Blueprint Studio",
+    url: "https://blueprintstudio.ai",
+  },
+};
+
+export default function Page() {
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <LaunchVideosComponent />
+    </>
+  );
+}

--- a/app/launch/page.tsx
+++ b/app/launch/page.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from "next";
+import LaunchComponent from "@/components/Launch/index";
 
 export const metadata: Metadata = {
   // Layout template appends " | Blueprint Studio" — keep this bare to avoid doubling.
@@ -42,4 +43,39 @@ export const metadata: Metadata = {
   },
 };
 
-export { default } from "@/components/Launch/index";
+// Page-specific structured data (the layout already provides WebSite +
+// Organization). Describes the Full Launch Package service and its starting price.
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@type": "Service",
+  name: "Full Launch Package",
+  serviceType: "Startup launch package",
+  description:
+    "Everything you need to launch. Brand identity, website, pitch deck, launch video. One team, one price, six weeks.",
+  url: "https://blueprintstudio.ai/launch",
+  areaServed: "Worldwide",
+  provider: {
+    "@type": "Organization",
+    name: "Blueprint Studio",
+    url: "https://blueprintstudio.ai",
+  },
+  offers: {
+    "@type": "Offer",
+    priceCurrency: "USD",
+    price: "50000",
+    url: "https://blueprintstudio.ai/launch",
+    availability: "https://schema.org/InStock",
+  },
+};
+
+export default function Page() {
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <LaunchComponent />
+    </>
+  );
+}


### PR DESCRIPTION
## What
Follow-up to #27 (sitemap + legal noindex). Fills the remaining structured-data / metadata gaps found in the SEO audit.

- **`/launch`** — `Service` JSON-LD with the $50K `Offer` (mirrors `/brand`).
- **`/launch-videos`** — `Service` JSON-LD (no price advertised, so no `Offer`).
- **`/brands/jinba`** — was the least-complete content page: added **self-canonical**, **keywords**, and **`CreativeWork` JSON-LD**.

`/launch` and `/launch-videos` re-exported their component (`export { default } from ...`); wrapped each in a small `Page()` so the `ld+json` `<script>` can render alongside.

## Verified (local dev server)
- `/launch` → `@type: Service` + `price: 50000` ✅
- `/launch-videos` → `@type: Service` + `serviceType: Launch video production` ✅
- `/brands/jinba` → `@type: CreativeWork` + canonical `/brands/jinba` ✅
- `tsc --noEmit` clean ✅

## Not included
`/insights` + `/insights/[slug]` keywords — negligible SEO value and would touch the blog data model; skipped intentionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)