### PR TITLE
SEO: launch-videos pricing tiers + JSON-LD XSS-escaping

### DIFF
--- a/app/brand/page.tsx
+++ b/app/brand/page.tsx
@@ -74,7 +74,7 @@ export default function Page() {
     <>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd).replace(/</g, "\\u003c") }}
       />
       <BrandPage />
     </>

--- a/app/brands/jinba/page.tsx
+++ b/app/brands/jinba/page.tsx
@@ -155,7 +155,7 @@ export default function JinbaPage() {
     <div className="min-h-screen bg-[#F5F5F5] max-w-[1800px] mx-auto lg:pl-[10rem]">
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd).replace(/</g, "\\u003c") }}
       />
       <BrandNav clientName="Jinba" logoSrc="/brands/jinba/dl/lockup-small-dark.png" />
       <BrandToC chapters={TOC_CHAPTERS} pdfHref="https://drive.google.com/file/d/1zZaz_NnLIcT-b2WeNSgJn1VO9Nry83dx/view?usp=sharing" />

--- a/app/launch-videos/page.tsx
+++ b/app/launch-videos/page.tsx
@@ -47,7 +47,8 @@ export const metadata: Metadata = {
 };
 
 // Page-specific structured data (the layout already provides WebSite +
-// Organization). Describes the Launch Videos production service.
+// Organization). Describes the Launch Videos production service and its two
+// pricing tiers (see components/LaunchVideos/PricingSection.tsx).
 const jsonLd = {
   "@context": "https://schema.org",
   "@type": "Service",
@@ -62,6 +63,24 @@ const jsonLd = {
     name: "Blueprint Studio",
     url: "https://blueprintstudio.ai",
   },
+  offers: [
+    {
+      "@type": "Offer",
+      name: "Fast",
+      priceCurrency: "USD",
+      price: "8000",
+      url: "https://blueprintstudio.ai/launch-videos",
+      availability: "https://schema.org/InStock",
+    },
+    {
+      "@type": "Offer",
+      name: "Studio",
+      priceCurrency: "USD",
+      price: "15000",
+      url: "https://blueprintstudio.ai/launch-videos",
+      availability: "https://schema.org/InStock",
+    },
+  ],
 };
 
 export default function Page() {
@@ -69,7 +88,7 @@ export default function Page() {
     <>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd).replace(/</g, "\\u003c") }}
       />
       <LaunchVideosComponent />
     </>

--- a/app/launch/page.tsx
+++ b/app/launch/page.tsx
@@ -73,7 +73,7 @@ export default function Page() {
     <>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd).replace(/</g, "\\u003c") }}
       />
       <LaunchComponent />
     </>


### PR DESCRIPTION
Follow-up to #28.

## Fixes
- **`/launch-videos` had a price after all.** `PricingSection.tsx` advertises two tiers — Fast **$8,000** and Studio **$15,000**. Replaced the Offer-less `Service` with an `offers: [Offer, Offer]` array carrying both named tiers.
- **Escaped `<` → `<`** in all four JSON-LD `<script>` blocks (`/brand`, `/launch`, `/launch-videos`, `/brands/jinba`) — the XSS-hardening Next.js's JSON-LD docs recommend. Our payloads are 100% static literals so there's no actual vector, but it's the documented best practice and keeps the scripts uniform (`/brand` predated this and was unescaped).

## Verified (local dev server)
- `/launch-videos` JSON-LD → `name: Fast / price: 8000` + `name: Studio / price: 15000` ✅
- All four JSON-LD blocks still parse as valid `Service` / `CreativeWork` ✅
- `tsc --noEmit` clean ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)