### PR TITLE
fix(footer): keep "Asset Generator" link on one line

### DIFF
--- a/components/Footer/index.tsx
+++ b/components/Footer/index.tsx
@@ -105,7 +105,7 @@ export function Footer() {
                           href={link.href}
                           target="_blank"
                           rel="noopener noreferrer"
-                          className="text-neutral-500 hover:text-neutral-300 text-sm transition-colors duration-200 flex items-center gap-1 w-fit"
+                          className="text-neutral-500 hover:text-neutral-300 text-sm transition-colors duration-200 flex items-center gap-1 w-fit whitespace-nowrap"
                         >
                           {link.name}
                           <svg


### PR DESCRIPTION
## What

The **Products** footer column is fixed at `md:w-[120px]`, and "Asset Generator" + the external-link arrow just exceeds that width, so it wraps to two lines.

Adds `whitespace-nowrap` to the external footer link so "Asset Generator" stays on one line. As the last column in the row, its slight overflow spills harmlessly into empty space to the right; on mobile the column is full-width so it's unaffected.

## Change
- `components/Footer/index.tsx`: add `whitespace-nowrap` to the external-link className.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mo91YWLU8wRABVQDDAJPVa